### PR TITLE
If we find an error during compilation don't try to compile other rules

### DIFF
--- a/src/yara.cc
+++ b/src/yara.cc
@@ -455,6 +455,10 @@ public:
 									: NULL
 						);
 				}
+
+				if (error_count > 0) {
+					break;
+				}
 			}
 			
 			if (error_count == 0) {

--- a/src/yara.cc
+++ b/src/yara.cc
@@ -460,7 +460,7 @@ public:
 					break;
 				}
 			}
-			
+
 			if (error_count == 0) {
 				rc = yr_compiler_get_rules(scanner_->compiler, &scanner_->rules);
 				if (rc != ERROR_SUCCESS)
@@ -531,7 +531,7 @@ void compileCallback(int error_level, const char* file_name, int line_number,
 	CompileArgs* args = (CompileArgs*) user_data;
 
 	std::ostringstream oss;
-	oss << args->rule_config->index << ":" << line_number << ":" << message;
+	oss << args->rule_config->index << ":" << line_number << ":" << message << ":" << file_name;
 
 	if (error_level == YARA_ERROR_LEVEL_WARNING)
 		args->configure->warnings.push_back(oss.str());
@@ -1088,7 +1088,7 @@ NAN_METHOD(ScannerWrap::Scan) {
 			scan_req,
 			callback
 		);
-	
+
 	async_scan->matched_bytes = matched_bytes;
 
 	Nan::AsyncQueueWorker(async_scan);

--- a/test/unit_index.js_scanner.configure.js
+++ b/test/unit_index.js_scanner.configure.js
@@ -63,6 +63,30 @@ describe("index.js", function() {
 				})
 		})
 
+		it("rules.string - errors if more than one bad rule", function(done) {
+			var scanner = yara.createScanner()
+
+			scanner.configure({
+					rules: [
+						{string: "rule bad {}"},
+						{string: "rule bad {}"}
+					]
+				}, function(error) {
+					assert(error instanceof yara.CompileRulesError)
+					assert(error.message == "Error compiling rules")
+
+					var expErrors = [{
+						index: 0,
+						line: 1,
+						message: "syntax error, unexpected '}', expecting <condition>"
+					}]
+
+					assert.deepEqual(error.errors, expErrors)
+
+					done()
+				})
+		})
+
 		it("rules.string - valid", function(done) {
 			var scanner = yara.createScanner()
 


### PR DESCRIPTION
YARA has an assertion that the compiler had zero errors when trying to compile something, if a bad rule is found and later you try to compile another rule that assertion fails and the process is halted. 

In the case of sending an array of rules if one of them was a bad rule when we iterated to the next one this would happen and we don't end up getting the output showing what's wrong with the rule. This patch aims to fix that.